### PR TITLE
Simplify by using `T: Display` instead of `Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ license = "MPL-2.0"
 
 [dependencies]
 
-[features]
-rust2015 = []
-default = []

--- a/README.md
+++ b/README.md
@@ -57,15 +57,7 @@ fn main() -> Result<(), Terminator> {
 
 ## Minimum version
 We support a minimum `rustc` version of `1.26.0` as this was when the question
-mark in main feature was stabilized. However, for versions less than `1.31.0`
-you'll need to set the feature flag `rust2015` in your `Cargo.toml` like so:
-
-```toml
-[dependencies]
-terminator = { version = "0.1", default-features = false, features = "rust2015" }
-```
-
-This is to get around that `dyn` is required in 2018, while in 2015 it was not.
+mark in main feature was stabilized.
 
 ## License
 

--- a/examples/debug-2015.rs
+++ b/examples/debug-2015.rs
@@ -1,7 +1,0 @@
-use std::fs;
-use std::error::Error;
-
-fn main() -> Result<(), Box<Error>> {
-    fs::read_to_string("path/does/not/exist")?;
-    Ok(())
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in a binary program that people would want to use. To get around this people
 //! continue to use the same pattern we had before `rustc 1.26.0`, namely:
 //!
-//! ```rust
+//! ```rust,ignore
 //! fn main() {
 //!   if let Err(e) = run() {
 //!     eprintln!("{}", e);
@@ -33,7 +33,7 @@
 //!
 //! What we want is this code, but it outputs a `Display` value:
 //!
-//! ```rust
+//! ```rust,ignore
 //! fn main() -> Result<(), SomeDisplayError> {
 //!   my_possible_failure_fn()?;
 //!   Ok(())
@@ -52,6 +52,8 @@
 //! look something like this:
 //!
 //! ```rust
+//! # fn your_possible_failure_fn() -> Result<(), Box<dyn std::error::Error>>
+//! # { Ok(()) }
 //! use terminator::Terminator;
 //! fn main() -> Result<(), Terminator> {
 //!   your_possible_failure_fn()?;
@@ -62,75 +64,19 @@
 //!
 //! ## Minimum version
 //! We support a minimum `rustc` version of `1.26.0` as this was when the question
-//! mark in main feature was stabilized. However, for versions less than `1.31.0`
-//! you'll need to set the feature flag `rust2015` in your `Cargo.toml` like so:
-//!
-//! ```toml
-//! [dependencies]
-//! terminator = { version = "0.1", default-features = false, features = "rust2015" }
+//! mark in main feature was stabilized.
 //! ```
 
-use std::error::Error;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
 
 /// A type that lets you output your error as `Display` for `fn main() -> Result<(), Error>`
 pub struct Terminator {
     err: String
 }
 
-/// This impl block is what does all of the work. Rust has some rules regarding what traits can be
-/// implemented for what. Initially the this was what was written:
-///
-/// ```rust
-/// use std::error::Error;
-/// impl<T: Error> From<T> for Terminator {
-/// ```
-///
-/// However, we run into issues of cohesion and specialization. There exists an impl defined in
-/// stdlib of this form:
-///
-/// ```rust
-/// impl<T> From<T> for T {
-/// ```
-///
-/// Which impl then should Rust use? While we know it's more specialized `rustc` does not. On top
-/// of this we are violating coherence meaning that we have more than one impl for each given type.
-/// What's a programmer to do then in this case? We want to be able to say I want to restrict this
-/// to types that implement `std::error::Error`. Well the good news is that we can with `Into` and
-/// some `Box` magic.
-///
-/// This is the actual impl that does all our magic:
-///
-/// ```rust
-/// use std::error::Error;
-/// impl<T: Into<Box<dyn Error>>> From<T> for Terminator {
-/// ```
-///
-/// We are not asking for any given `T` that impls `std::error::Error`! We are asking only the ones
-/// that can turn into a `Box<dyn Error>`. Since we are then turning into another type we're not
-/// actually breaking cohesion. Dynamic dispatch allows us to do what we originally wanted with
-/// only some overhead. With this impl `?` now works for any type that can turn into `Box<dyn
-/// Error>` which should be all error types that implement `std::error::Error`.
-///
-/// Why do we care so much about `std::error::Error`? The neat thing is that besides restricting
-/// ourselves to only types that are errors, we also get a type that implements `Display` since
-/// that is one of `std::error::Error`'s trait bounds. What is a little less known is that if you
-/// implement `Display` for a type, you implicitly get `ToString`. It's kind of like how if you
-/// implement `From` you automatically get `Into`. As a result calling `to_string()` on this error
-/// type gives us what it would look like if it was display, so during our conversion we just call
-/// `.into().to_string()` on the input to `From` and store the value to then be dumped to stdout.
-/// Then all we have after this is a simple `Debug` implementation for `Terminator` that just dumps
-/// that string out as if it was `Display`!
-#[cfg(not(feature = "rust2015"))]
-impl<T: Into<Box<dyn Error>>> From<T> for Terminator {
+impl<T: Display> From<T> for Terminator {
     fn from(err: T) -> Self {
-        Self { err: err.into().to_string() }
-    }
-}
-#[cfg(feature = "rust2015")]
-impl<T: Into<Box<Error>>> From<T> for Terminator {
-    fn from(err: T) -> Self {
-        Self { err: err.into().to_string() }
+        Self { err: err.to_string() }
     }
 }
 


### PR DESCRIPTION
This should be enough to get rid of all the workarounds:

```
impl<T: Display> From<T> for Terminator {
    fn from(err: T) -> Self {
        Self { err: err.to_string() }
    }
}
```