### PR TITLE
Allow `Terminator` to be used in more places

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in a binary program that people would want to use. To get around this people
 //! continue to use the same pattern we had before `rustc 1.26.0`, namely:
 //!
-//! ```rust
+//! ```ignore
 //! fn main() {
 //!   if let Err(e) = run() {
 //!     eprintln!("{}", e);
@@ -33,7 +33,7 @@
 //!
 //! What we want is this code, but it outputs a `Display` value:
 //!
-//! ```rust
+//! ```ignore
 //! fn main() -> Result<(), SomeDisplayError> {
 //!   my_possible_failure_fn()?;
 //!   Ok(())
@@ -47,11 +47,14 @@
 //!
 //! ## How to use it
 //!
-//! Just have your `main` function return `Return<(), Terminator>` or if you need
-//! to use it's never type implementation `Return<!, Terminator>`. Your code should
-//! look something like this:
+//! Just have your `main` function return `Return<(), Terminator<YourError>>` or
+//! if you need to use it's never type implementation `Return<!,
+//! Terminator<YourError>>`. You can leave off the explicit error type if you
+//! want `Box<dyn Error>`.
 //!
-//! ```rust
+//! Your code should look something like this:
+//!
+//! ```ignore
 //! use terminator::Terminator;
 //! fn main() -> Result<(), Terminator> {
 //!   your_possible_failure_fn()?;
@@ -71,73 +74,62 @@
 //! ```
 
 use std::error::Error;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
+
+#[doc(hidden)]
+#[cfg(not(rust2015))]
+type DefaultError = Box<dyn Error>;
+
+#[doc(hidden)]
+#[cfg(rust2015)]
+type DefaultError = Box<Error>;
 
 /// A type that lets you output your error as `Display` for `fn main() -> Result<(), Error>`
-pub struct Terminator {
-    err: String
+pub struct Terminator<E = DefaultError> {
+    err: E
 }
 
-/// This impl block is what does all of the work. Rust has some rules regarding what traits can be
-/// implemented for what. Initially the this was what was written:
-///
-/// ```rust
-/// use std::error::Error;
-/// impl<T: Error> From<T> for Terminator {
-/// ```
-///
-/// However, we run into issues of cohesion and specialization. There exists an impl defined in
-/// stdlib of this form:
-///
-/// ```rust
-/// impl<T> From<T> for T {
-/// ```
-///
-/// Which impl then should Rust use? While we know it's more specialized `rustc` does not. On top
-/// of this we are violating coherence meaning that we have more than one impl for each given type.
-/// What's a programmer to do then in this case? We want to be able to say I want to restrict this
-/// to types that implement `std::error::Error`. Well the good news is that we can with `Into` and
-/// some `Box` magic.
-///
-/// This is the actual impl that does all our magic:
-///
-/// ```rust
-/// use std::error::Error;
-/// impl<T: Into<Box<dyn Error>>> From<T> for Terminator {
-/// ```
-///
-/// We are not asking for any given `T` that impls `std::error::Error`! We are asking only the ones
-/// that can turn into a `Box<dyn Error>`. Since we are then turning into another type we're not
-/// actually breaking cohesion. Dynamic dispatch allows us to do what we originally wanted with
-/// only some overhead. With this impl `?` now works for any type that can turn into `Box<dyn
-/// Error>` which should be all error types that implement `std::error::Error`.
-///
-/// Why do we care so much about `std::error::Error`? The neat thing is that besides restricting
-/// ourselves to only types that are errors, we also get a type that implements `Display` since
-/// that is one of `std::error::Error`'s trait bounds. What is a little less known is that if you
-/// implement `Display` for a type, you implicitly get `ToString`. It's kind of like how if you
-/// implement `From` you automatically get `Into`. As a result calling `to_string()` on this error
-/// type gives us what it would look like if it was display, so during our conversion we just call
-/// `.into().to_string()` on the input to `From` and store the value to then be dumped to stdout.
-/// Then all we have after this is a simple `Debug` implementation for `Terminator` that just dumps
-/// that string out as if it was `Display`!
-#[cfg(not(feature = "rust2015"))]
-impl<T: Into<Box<dyn Error>>> From<T> for Terminator {
+impl<T: Into<E> + Display, E> From<T> for Terminator<E> {
     fn from(err: T) -> Self {
-        Self { err: err.into().to_string() }
-    }
-}
-#[cfg(feature = "rust2015")]
-impl<T: Into<Box<Error>>> From<T> for Terminator {
-    fn from(err: T) -> Self {
-        Self { err: err.into().to_string() }
+        Self {
+            err: err.into(),
+        }
     }
 }
 
 /// A manually implemented implementation of `Debug` that writes the error out to stderr as if it
 /// was `Display`
-impl Debug for Terminator {
+impl<E: Display> Debug for Terminator<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}", self.err)
     }
+}
+
+#[test]
+fn terminator_can_be_used_with_send_and_sync() {
+    let x: Box<dyn Error + Send + Sync> = "hi".into();
+    assert_eq!("hi", format!("{:?}", Terminator::<Box<dyn Error + Send + Sync>>::from(x)));
+}
+
+#[test]
+fn terminator_can_be_used_anywhere_question_mark_can() {
+    struct MyError(String);
+
+    impl<T: Into<String>> From<T> for MyError {
+        fn from(s: T) -> Self {
+            MyError(s.into())
+        }
+    }
+
+    impl Display for MyError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            write!(f, "oh no: {}", self.0)
+        }
+    }
+
+    fn return_my_error() -> Result<(), Terminator<MyError>> {
+        Err("hi")?
+    }
+
+    assert_eq!("oh no: hi", format!("{:?}", return_my_error().unwrap_err()));
 }


### PR DESCRIPTION
The implementation of `Terminator` is pretty restrictive. There's two
notable places where it falls over:

- It cannot be used if any of the functions you're calling return any
  trait object other than `Box<dyn Error>`. An extremely common type is
  `Box<dyn Error + Send + Sync>`.
- Changing `Result<T, E>` to `Result<T, Terminator>` potentially loses
  context, since you're coercing directly from the expression `?` was
  used on to `Box<dyn Error>`, not `E` first.

The first is a major issue, and cannot be fixed without something
similar to this commit. The second issue could be worked around by
wrapping everything in another function with the error type you want to
convert to, but now we're basically stuck back in 1.25 days. It's also
especially annoying to do that in tests.

This commit addresses these issues by changing `Terminator` to be
generic over any type (with the default being `Box<dyn Error>` to keep
similar behavior as before, and providing an extremely generic `From`
impl that says "we can be converted from any type which can convert to
our error type"

There is a wrinkle here, since the naive impl would overlap with
`impl<T> From<T> for T` in the standard library. To work around this,
I've required that the input type implement `Display`. This is a little
funky, since it means that the type we're converting *from* must
implement `Display`, when we actually only care that the type we're
converting *to* implements it. But it was the best bound I could think
of which does not apply to `Terminator<E>`, and is likely to apply to
every type used as an error.

In the rare case where you're converting from something that doesn't
implement display, you'd need an explicit intermeidate conversion, e.g.
`result.map_err(MyError::from)?`. This seems niche enough that I don't
even think it's worth documenting in the library.